### PR TITLE
optimize allocations during label filtering

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -200,10 +200,16 @@ func (m *Metrics) labelIsAllowed(label *Label) bool {
 // filterLabels return only allowed labels
 // the caller should lock m.filterLock while calling this method
 func (m *Metrics) filterLabels(labels []Label) []Label {
-	if labels == nil {
-		return nil
+	if len(labels) == 0 { // length of nil slice is also zero
+		return labels
 	}
-	toReturn := []Label{}
+
+	// return early if filtering isn't configured, this saves allocating a new Label slice.
+	if m.blockedLabels == nil && m.allowedLabels == nil {
+		return labels
+	}
+
+	var toReturn []Label
 	for _, label := range labels {
 		if m.labelIsAllowed(&label) {
 			toReturn = append(toReturn, label)


### PR DESCRIPTION
This showed up in some pprof profiling of our application. We do not have any blocked/allowed labels configured, however the library was still creating a duplicate of the `Label` slice on each call. This caused unnecessary allocations.

This PR cleans up some unnecessary allocations in the following edge cases: 
1. An empty (non nil) label slice is passed in. 
2. Neither blocked or allowed lists are configured.
3. No labels are allowed. 

Didn't see any contributing guides. Let me know if anything needs to change to get this merged!