### PR TITLE
fix: package name and other moved repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ go-metrics
 This library provides a `metrics` package which can be used to instrument code,
 expose application metrics, and profile runtime performance in a flexible manner.
 
-Current API: [![GoDoc](https://godoc.org/github.com/armon/go-metrics?status.svg)](https://godoc.org/github.com/armon/go-metrics)
+Current API: [![GoDoc](https://godoc.org/github.com/hashicorp/go-metrics?status.svg)](https://godoc.org/github.com/hashicorp/go-metrics)
 
 Sinks
 -----
@@ -12,8 +12,8 @@ Sinks
 The `metrics` package makes use of a `MetricSink` interface to support delivery
 to any type of backend. Currently the following sinks are provided:
 
-* StatsiteSink : Sinks to a [statsite](https://github.com/armon/statsite/) instance (TCP)
-* StatsdSink: Sinks to a [StatsD](https://github.com/etsy/statsd/) / statsite instance (UDP)
+* StatsiteSink : Sinks to a [statsite](https://github.com/statsite/statsite/) instance (TCP)
+* StatsdSink: Sinks to a [StatsD](hhttps://github.com/statsd/statsd/) / statsite instance (UDP)
 * PrometheusSink: Sinks to a [Prometheus](http://prometheus.io/) metrics endpoint (exposed via HTTP for scrapes)
 * InmemSink : Provides in-memory aggregation, can be used to export stats
 * FanoutSink : Sinks to multiple sinks. Enables writing to multiple statsite instances for example.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The `metrics` package makes use of a `MetricSink` interface to support delivery
 to any type of backend. Currently the following sinks are provided:
 
 * StatsiteSink : Sinks to a [statsite](https://github.com/statsite/statsite/) instance (TCP)
-* StatsdSink: Sinks to a [StatsD](hhttps://github.com/statsd/statsd/) / statsite instance (UDP)
+* StatsdSink: Sinks to a [StatsD](https://github.com/statsd/statsd/) / statsite instance (UDP)
 * PrometheusSink: Sinks to a [Prometheus](http://prometheus.io/) metrics endpoint (exposed via HTTP for scrapes)
 * InmemSink : Provides in-memory aggregation, can be used to export stats
 * FanoutSink : Sinks to multiple sinks. Enables writing to multiple statsite instances for example.

--- a/circonus/circonus.go
+++ b/circonus/circonus.go
@@ -5,8 +5,8 @@ package circonus
 import (
 	"strings"
 
-	"github.com/armon/go-metrics"
 	cgm "github.com/circonus-labs/circonus-gometrics"
+	"github.com/hashicorp/go-metrics"
 )
 
 // CirconusSink provides an interface to forward metrics to Circonus with

--- a/circonus/circonus_test.go
+++ b/circonus/circonus_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-metrics"
 )
 
 func TestNewCirconusSink(t *testing.T) {

--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-metrics"
 )
 
 // DogStatsdSink provides a MetricSink that can be used

--- a/datadog/dogstatsd_test.go
+++ b/datadog/dogstatsd_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-metrics"
 )
 
 var EmptyTags []metrics.Label

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/armon/go-metrics
+module github.com/hashicorp/go-metrics
 
 go 1.12
 

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 )

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	dto "github.com/prometheus/client_model/go"
 
-	"github.com/armon/go-metrics"
+	"github.com/hashicorp/go-metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/expfmt"
 )


### PR DESCRIPTION
When trying to `go get github.com/hashicorp/go-metrics`

This should fix it so it's possible to do above and not get:
```
go: downloading github.com/hashicorp/go-metrics v0.4.1
go: github.com/hashicorp/go-metrics@v0.4.1: parsing go.mod:
        module declares its path as: github.com/armon/go-metrics
                but was required as: github.com/hashicorp/go-metrics

```