### PR TITLE
prometheus: prevent panic when incrmenting counter

### DIFF
--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -168,6 +168,9 @@ func TestDefinitions(t *testing.T) {
 	sink.AddSample(summaryDef.Name, 42)
 	sink.IncrCounter(counterDef.Name, 1)
 
+	// Prometheus panic should not be propagated
+	sink.IncrCounter(counterDef.Name, -1)
+
 	// Test that the expiry behavior works as expected. First pick a time which
 	// is after all the actual updates above.
 	timeAfterUpdates := time.Now()
@@ -358,6 +361,11 @@ func TestDefinitionsWithLabels(t *testing.T) {
 			t.Fatalf("expected gauge to include correct help=%s, but was %s", counterDef.Help, metric.Desc().String())
 		}
 		return true
+	})
+
+	// Prometheus panic should not be propagated
+	sink.IncrCounterWithLabels(counterDef.Name, -1, []metrics.Label{
+		{Name: "version", Value: "some info"},
 	})
 }
 


### PR DESCRIPTION
The Prometheus [Counter.Add()](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#Counter) method panics if the value being added is negative. Even if care is taken by consumers to never pass a negative value the panic could still happen due to float conversion or overflow.

This change prevents go-metrics from causing consumers to crash.

A panic like this has been reported in https://github.com/hashicorp/nomad/issues/15861, but, as far as I can tell, Nomad only calls `IncrCounter` and `IncrCounterWithLabels` using positive values.