### PR TITLE
Go sched scheduler latency

### DIFF
--- a/metrics.go
+++ b/metrics.go
@@ -282,8 +282,9 @@ func (m *Metrics) EmitRuntimeStats() {
 
 func (m *Metrics) readSchedulerLatencyAll() {
 	sample := make([]metrics.Sample, 1)
-	const metricName = "/sched/latencies:seconds"
-	sample[0].Name = metricName
+	const metricName = "sched_latencies_seconds"
+	const goName = "/sched/latencies:seconds"
+	sample[0].Name = goName
 
 	metrics.Read(sample)
 	var signal *metrics.Float64Histogram
@@ -300,7 +301,7 @@ func (m *Metrics) readSchedulerLatencyAll() {
 				bucket = math.MaxFloat32
 			}
 			s := fmt.Sprintf("%f", bucket)
-			m.AddSampleWithLabels([]string{"runtime", strings.ReplaceAll(metricName, "/", "_")}, float32(c)*float32(bucket), []Label{{"bucket", s}})
+			m.AddSampleWithLabels([]string{"runtime", metricName}, float32(c)*float32(bucket), []Label{{"bucket", s}})
 		}
 	}
 }

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -303,6 +303,10 @@ func TestMetrics_EmitRuntimeStats(t *testing.T) {
 	if m.vals[8] <= 1000 {
 		t.Fatalf("bad val: %v", m.vals)
 	}
+
+	if m.getKeys()[9][0] != "runtime" || m.getKeys()[9][1] != "sched_latencies_seconds" {
+		t.Fatalf("bad key %v", m.getKeys())
+	}
 }
 
 func TestInsert(t *testing.T) {


### PR DESCRIPTION
This adds the scheduler queue latency metric to go-metric. This metric is interesting when profiling a go program.

As go-metrics don't support histograms and this metric is exposed as histogram in go runtime library, I chose to expose it in the following form `bucket*count`. This is not ideal as it's factor of total count of active goroutine so it could be misleading in some cases. That said, total count of goroutines is also available as a different metric, so it could help disambiguous this. 

Also, I think this is sufficient to measure the overall scheduling pressure caused by CPU bottlenecks or bugs in a given go program.