### PR TITLE
Add GaugeFloat64 API

### DIFF
--- a/circonus/circonus.go
+++ b/circonus/circonus.go
@@ -22,11 +22,11 @@ type Config cgm.Config
 // NewCirconusSink - create new metric sink for circonus
 //
 // one of the following must be supplied:
-//    - API Token - search for an existing check or create a new check
-//    - API Token + Check Id - the check identified by check id will be used
-//    - API Token + Check Submission URL - the check identified by the submission url will be used
-//    - Check Submission URL - the check identified by the submission url will be used
-//      metric management will be *disabled*
+//   - API Token - search for an existing check or create a new check
+//   - API Token + Check Id - the check identified by check id will be used
+//   - API Token + Check Submission URL - the check identified by the submission url will be used
+//   - Check Submission URL - the check identified by the submission url will be used
+//     metric management will be *disabled*
 //
 // Note: If submission url is supplied w/o an api token, the public circonus ca cert will be used
 // to verify the broker for metrics submission.

--- a/datadog/dogstatsd.go
+++ b/datadog/dogstatsd.go
@@ -87,6 +87,10 @@ func (s *DogStatsdSink) SetGauge(key []string, val float32) {
 	s.SetGaugeWithLabels(key, val, nil)
 }
 
+func (s *DogStatsdSink) SetPrecisionGauge(key []string, val float64) {
+	s.SetPrecisionGaugeWithLabels(key, val, nil)
+}
+
 func (s *DogStatsdSink) IncrCounter(key []string, val float32) {
 	s.IncrCounterWithLabels(key, val, nil)
 }
@@ -106,6 +110,14 @@ func (s *DogStatsdSink) SetGaugeWithLabels(key []string, val float32, labels []m
 	flatKey, tags := s.getFlatkeyAndCombinedLabels(key, labels)
 	rate := 1.0
 	s.client.Gauge(flatKey, float64(val), tags, rate)
+}
+
+// The following ...WithLabels methods correspond to Datadog's Tag extension to Statsd.
+// http://docs.datadoghq.com/guides/dogstatsd/#tags
+func (s *DogStatsdSink) SetPrecisionGaugeWithLabels(key []string, val float64, labels []metrics.Label) {
+	flatKey, tags := s.getFlatkeyAndCombinedLabels(key, labels)
+	rate := 1.0
+	s.client.Gauge(flatKey, val, tags, rate)
 }
 
 func (s *DogStatsdSink) IncrCounterWithLabels(key []string, val float32, labels []metrics.Label) {

--- a/inmem_signal.go
+++ b/inmem_signal.go
@@ -83,6 +83,10 @@ func (i *InmemSignal) dumpStats() {
 			name := i.flattenLabels(val.Name, val.Labels)
 			fmt.Fprintf(buf, "[%v][G] '%s': %0.3f\n", intv.Interval, name, val.Value)
 		}
+		for _, val := range intv.PrecisionGauges {
+			name := i.flattenLabels(val.Name, val.Labels)
+			fmt.Fprintf(buf, "[%v][G] '%s': %0.3f\n", intv.Interval, name, val.Value)
+		}
 		for name, vals := range intv.Points {
 			for _, val := range vals {
 				fmt.Fprintf(buf, "[%v][P] '%s': %0.3f\n", intv.Interval, name, val)

--- a/metrics.go
+++ b/metrics.go
@@ -42,6 +42,40 @@ func (m *Metrics) SetGaugeWithLabels(key []string, val float32, labels []Label) 
 	m.sink.SetGaugeWithLabels(key, val, labelsFiltered)
 }
 
+func (m *Metrics) SetPrecisionGauge(key []string, val float64) {
+	m.SetPrecisionGaugeWithLabels(key, val, nil)
+}
+
+func (m *Metrics) SetPrecisionGaugeWithLabels(key []string, val float64, labels []Label) {
+	if m.HostName != "" {
+		if m.EnableHostnameLabel {
+			labels = append(labels, Label{"host", m.HostName})
+		} else if m.EnableHostname {
+			key = insert(0, m.HostName, key)
+		}
+	}
+	if m.EnableTypePrefix {
+		key = insert(0, "gauge", key)
+	}
+	if m.ServiceName != "" {
+		if m.EnableServiceLabel {
+			labels = append(labels, Label{"service", m.ServiceName})
+		} else {
+			key = insert(0, m.ServiceName, key)
+		}
+	}
+	allowed, labelsFiltered := m.allowMetric(key, labels)
+	if !allowed {
+		return
+	}
+	sink, ok := m.sink.(PrecisionGaugeMetricSink)
+	if !ok {
+		// Sink does not implement PrecisionGaugeMetricSink.
+	} else {
+		sink.SetPrecisionGaugeWithLabels(key, val, labelsFiltered)
+	}
+}
+
 func (m *Metrics) EmitKey(key []string, val float32) {
 	if m.EnableTypePrefix {
 		key = insert(0, "kv", key)

--- a/metrics_test.go
+++ b/metrics_test.go
@@ -68,6 +68,61 @@ func TestMetrics_SetGauge(t *testing.T) {
 	}
 }
 
+func TestMetrics_SetPrecisionGauge(t *testing.T) {
+	m, met := mockMetric()
+	met.SetPrecisionGauge([]string{"key"}, float64(1))
+	if m.getKeys()[0][0] != "key" {
+		t.Fatalf("")
+	}
+	if m.precisionVals[0] != 1 {
+		t.Fatalf("")
+	}
+
+	m, met = mockMetric()
+	labels := []Label{{"a", "b"}}
+	met.SetPrecisionGaugeWithLabels([]string{"key"}, float64(1), labels)
+	if m.getKeys()[0][0] != "key" {
+		t.Fatalf("")
+	}
+	if m.precisionVals[0] != 1 {
+		t.Fatalf("")
+	}
+	if !reflect.DeepEqual(m.labels[0], labels) {
+		t.Fatalf("")
+	}
+
+	m, met = mockMetric()
+	met.HostName = "test"
+	met.EnableHostname = true
+	met.SetPrecisionGauge([]string{"key"}, float64(1))
+	if m.getKeys()[0][0] != "test" || m.getKeys()[0][1] != "key" {
+		t.Fatalf("")
+	}
+	if m.precisionVals[0] != 1 {
+		t.Fatalf("")
+	}
+
+	m, met = mockMetric()
+	met.EnableTypePrefix = true
+	met.SetPrecisionGauge([]string{"key"}, float64(1))
+	if m.getKeys()[0][0] != "gauge" || m.getKeys()[0][1] != "key" {
+		t.Fatalf("")
+	}
+	if m.precisionVals[0] != 1 {
+		t.Fatalf("")
+	}
+
+	m, met = mockMetric()
+	met.ServiceName = "service"
+	met.SetPrecisionGauge([]string{"key"}, float64(1))
+	if m.getKeys()[0][0] != "service" || m.getKeys()[0][1] != "key" {
+		t.Fatalf("")
+	}
+	if m.precisionVals[0] != 1 {
+		t.Fatalf("")
+	}
+}
+
 func TestMetrics_EmitKey(t *testing.T) {
 	m, met := mockMetric()
 	met.EmitKey([]string{"key"}, float32(1))

--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -270,10 +270,18 @@ func prometheusLabels(labels []metrics.Label) prometheus.Labels {
 }
 
 func (p *PrometheusSink) SetGauge(parts []string, val float32) {
-	p.SetGaugeWithLabels(parts, val, nil)
+	p.SetPrecisionGauge(parts, float64(val))
 }
 
 func (p *PrometheusSink) SetGaugeWithLabels(parts []string, val float32, labels []metrics.Label) {
+	p.SetPrecisionGaugeWithLabels(parts, float64(val), labels)
+}
+
+func (p *PrometheusSink) SetPrecisionGauge(parts []string, val float64) {
+	p.SetPrecisionGaugeWithLabels(parts, val, nil)
+}
+
+func (p *PrometheusSink) SetPrecisionGaugeWithLabels(parts []string, val float64, labels []metrics.Label) {
 	key, hash := flattenKey(parts, labels)
 	pg, ok := p.gauges.Load(hash)
 
@@ -285,7 +293,7 @@ func (p *PrometheusSink) SetGaugeWithLabels(parts []string, val float32, labels 
 	// value, but since we're always setting it to time.Now(), it doesn't really matter.
 	if ok {
 		localGauge := *pg.(*gauge)
-		localGauge.Set(float64(val))
+		localGauge.Set(val)
 		localGauge.updatedAt = time.Now()
 		p.gauges.Store(hash, &localGauge)
 
@@ -301,7 +309,7 @@ func (p *PrometheusSink) SetGaugeWithLabels(parts []string, val float32, labels 
 			Help:        help,
 			ConstLabels: prometheusLabels(labels),
 		})
-		g.Set(float64(val))
+		g.Set(val)
 		pg = &gauge{
 			Gauge:     g,
 			updatedAt: time.Now(),

--- a/prometheus/prometheus_test.go
+++ b/prometheus/prometheus_test.go
@@ -297,6 +297,27 @@ func TestSetGauge(t *testing.T) {
 	}
 }
 
+func TestSetPrecisionGauge(t *testing.T) {
+	q := make(chan string)
+	server := fakeServer(q)
+	defer server.Close()
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		log.Fatal(err)
+	}
+	host := u.Hostname() + ":" + u.Port()
+	sink, err := NewPrometheusPushSink(host, time.Second, "pushtest")
+	metricsConf := metrics.DefaultConfig("default")
+	metricsConf.HostName = MockGetHostname()
+	metricsConf.EnableHostnameLabel = true
+	metrics.NewGlobal(metricsConf, sink)
+	metrics.SetPrecisionGauge([]string{"one", "two"}, 42)
+	response := <-q
+	if response != "ok" {
+		t.Fatal(response)
+	}
+}
+
 func TestDefinitionsWithLabels(t *testing.T) {
 	gaugeDef := GaugeDefinition{
 		Name: []string{"my", "test", "gauge"},

--- a/sink_test.go
+++ b/sink_test.go
@@ -10,10 +10,11 @@ import (
 type MockSink struct {
 	lock sync.Mutex
 
-	shutdown bool
-	keys     [][]string
-	vals     []float32
-	labels   [][]Label
+	shutdown      bool
+	keys          [][]string
+	vals          []float32
+	precisionVals []float64
+	labels        [][]Label
 }
 
 func (m *MockSink) getKeys() [][]string {
@@ -32,6 +33,17 @@ func (m *MockSink) SetGaugeWithLabels(key []string, val float32, labels []Label)
 
 	m.keys = append(m.keys, key)
 	m.vals = append(m.vals, val)
+	m.labels = append(m.labels, labels)
+}
+func (m *MockSink) SetPrecisionGauge(key []string, val float64) {
+	m.SetPrecisionGaugeWithLabels(key, val, nil)
+}
+func (m *MockSink) SetPrecisionGaugeWithLabels(key []string, val float64, labels []Label) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.keys = append(m.keys, key)
+	m.precisionVals = append(m.precisionVals, val)
 	m.labels = append(m.labels, labels)
 }
 func (m *MockSink) EmitKey(key []string, val float32) {

--- a/start.go
+++ b/start.go
@@ -97,12 +97,27 @@ func NewGlobal(conf *Config, sink MetricSink) (*Metrics, error) {
 }
 
 // Proxy all the methods to the globalMetrics instance
+
+// Set gauge key and value with 32 bit precision
 func SetGauge(key []string, val float32) {
 	globalMetrics.Load().(*Metrics).SetGauge(key, val)
 }
 
+// Set gauge key and value with 32 bit precision
 func SetGaugeWithLabels(key []string, val float32, labels []Label) {
 	globalMetrics.Load().(*Metrics).SetGaugeWithLabels(key, val, labels)
+}
+
+// Set gauge key and value with 64 bit precision
+// The Sink needs to implement PrecisionGaugeMetricSink, in case it doesn't,  the metric value won't be set and ingored instead
+func SetPrecisionGauge(key []string, val float64) {
+	globalMetrics.Load().(*Metrics).SetPrecisionGauge(key, val)
+}
+
+// Set gauge key, value with 64 bit precision, and labels
+// The Sink needs to implement PrecisionGaugeMetricSink, in case it doesn't, the metric value won't be set and ingored instead
+func SetPrecisionGaugeWithLabels(key []string, val float64, labels []Label) {
+	globalMetrics.Load().(*Metrics).SetPrecisionGaugeWithLabels(key, val, labels)
 }
 
 func EmitKey(key []string, val float32) {

--- a/statsd.go
+++ b/statsd.go
@@ -55,6 +55,16 @@ func (s *StatsdSink) SetGaugeWithLabels(key []string, val float32, labels []Labe
 	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
 }
 
+func (s *StatsdSink) SetPrecisionGauge(key []string, val float64) {
+	flatKey := s.flattenKey(key)
+	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
+}
+
+func (s *StatsdSink) SetPrecisionGaugeWithLabels(key []string, val float64, labels []Label) {
+	flatKey := s.flattenKeyLabels(key, labels)
+	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
+}
+
 func (s *StatsdSink) EmitKey(key []string, val float32) {
 	flatKey := s.flattenKey(key)
 	s.pushMetric(fmt.Sprintf("%s:%f|kv\n", flatKey, val))

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -119,6 +119,8 @@ func TestStatsd_Conn(t *testing.T) {
 
 	s.SetGauge([]string{"gauge", "val"}, float32(1))
 	s.SetGaugeWithLabels([]string{"gauge_labels", "val"}, float32(2), []Label{{"a", "label"}})
+	s.SetPrecisionGauge([]string{"gauge", "val"}, float64(1))
+	s.SetPrecisionGaugeWithLabels([]string{"gauge_labels", "val"}, float64(2), []Label{{"a", "label"}})
 	s.EmitKey([]string{"key", "other"}, float32(3))
 	s.IncrCounter([]string{"counter", "me"}, float32(4))
 	s.IncrCounterWithLabels([]string{"counter_labels", "me"}, float32(5), []Label{{"a", "label"}})

--- a/statsite.go
+++ b/statsite.go
@@ -55,6 +55,16 @@ func (s *StatsiteSink) SetGaugeWithLabels(key []string, val float32, labels []La
 	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
 }
 
+func (s *StatsiteSink) SetPrecisionGauge(key []string, val float64) {
+	flatKey := s.flattenKey(key)
+	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
+}
+
+func (s *StatsiteSink) SetPrecisionGaugeWithLabels(key []string, val float64, labels []Label) {
+	flatKey := s.flattenKeyLabels(key, labels)
+	s.pushMetric(fmt.Sprintf("%s:%f|g\n", flatKey, val))
+}
+
 func (s *StatsiteSink) EmitKey(key []string, val float32) {
 	flatKey := s.flattenKey(key)
 	s.pushMetric(fmt.Sprintf("%s:%f|kv\n", flatKey, val))

--- a/statsite_test.go
+++ b/statsite_test.go
@@ -116,6 +116,8 @@ func TestStatsite_Conn(t *testing.T) {
 
 	s.SetGauge([]string{"gauge", "val"}, float32(1))
 	s.SetGaugeWithLabels([]string{"gauge_labels", "val"}, float32(2), []Label{{"a", "label"}})
+	s.SetPrecisionGauge([]string{"gauge", "val"}, float64(1))
+	s.SetPrecisionGaugeWithLabels([]string{"gauge_labels", "val"}, float64(2), []Label{{"a", "label"}})
 	s.EmitKey([]string{"key", "other"}, float32(3))
 	s.IncrCounter([]string{"counter", "me"}, float32(4))
 	s.IncrCounterWithLabels([]string{"counter_labels", "me"}, float32(5), []Label{{"a", "label"}})


### PR DESCRIPTION
This adds a new API to send and store gauge metrics as float64s. Previously, they were being stored as float32s which isn't enough precision for storing unix timestamps. 

Related issue: https://github.com/hashicorp/vault/issues/19594 and https://github.com/hashicorp/go-metrics/issues/150