### PR TITLE
Introduce `compat` package to ease migration from the old armon/go-metrice module name to the current hashicorp/go-metrics name

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ go-metrics exporting via the `armon` namespace, then any metrics sent to go-metr
 will never get exported.
 
 Eventually all usage of `armon/go-metrics` should be replaced with usage of `hashicorp/go-metrics`. However, a single
-point-in-time coordinated update across all libraries than an application may depend on isn't always feasible. To faciliate migrations, 
+point-in-time coordinated update across all libraries that an application may depend on isn't always feasible. To facilitate migrations, 
 a `github.com/hashicorp/go-metrics/compat` package has been introduced. This package and sub-packages are API compatible with
 `armon/go-metrics`. Libraries should be updated to use this package for emitting metrics via the global handlers. Internally,
 the package will route metrics to either `armon/go-metrics` or `hashicorp/go-metrics`. This is achieved at a global level

--- a/README.md
+++ b/README.md
@@ -41,6 +41,46 @@ By default, both `Config.AllowedLabels` and `Config.BlockedLabels` are nil, mean
 no tags are filtered at all, but it allows a user to globally block some tags with high
 cardinality at the application level.
 
+Backwards Compatibility
+-----------------------
+v0.5.0 of the library renamed the Go module from `github.com/armon/go-metrics` to `github.com/hashicorp/go-metrics`. 
+While this did not introduce any breaking changes to the API, the change did subtly break backwards compatibility.
+
+In essence, Go treats a renamed module as entirely distinct and will happily compile both modules into the same binary.
+Due to most uses of the go-metrics library involving emitting metrics via the global metrics handler, having two global
+metrics handlers could cause a subset of metrics to be effectively lost. As an example, if your application configures
+go-metrics exporting via the `armon` namespace, then any metrics sent to go-metrics via the `hashicorp` namespaced module
+will never get exported.
+
+Eventually all usage of `armon/go-metrics` should be replaced with usage of `hashicorp/go-metrics`. However, a single
+point-in-time coordinated update across all libraries than an application may depend on isn't always feasible. To faciliate migrations, 
+a `github.com/hashicorp/go-metrics/compat` package has been introduced. This package and sub-packages are API compatible with
+`armon/go-metrics`. Libraries should be updated to use this package for emitting metrics via the global handlers. Internally,
+the package will route metrics to either `armon/go-metrics` or `hashicorp/go-metrics`. This is achieved at a global level
+within an application via the use of Go build tags.
+
+**Build Tags**
+* `armonmetrics` - Using this tag will cause metrics to be routed to `armon/go-metrics`
+* `hashicorpmetrics` - Using this tag will cause all metrics to be routed to `hashicorp/go-metrics`
+
+If no build tag is specified, the default behavior is to use `armon/go-metrics`. The overall migration path would be as follows:
+
+1. Upgrade libraries using `armon/go-metrics` to consume `hashicorp/go-metrics/compat` instead.
+2. Update library dependencies of applications that use `armon/go-metrics`. 
+   * This doesn't need to be one big atomic update but can be slower due to the default behavior remaining unaltered.
+   * At this point all metrics will still be emitted to `armon/go-metrics`
+3. Update the application to use `hashicorp/go-metrics`
+   * Replace all application imports of `github.com/armon/go-metrics` with `github.com/hashicorp/go-metrics`
+   * Libraries are unaltered at this stage.
+   * Instrument your build system to build with the `hashicorpmetrics` tag.
+
+Your migration is effectively finished and your application is now exclusively using `hashicorp/go-metrics`. A future release of the library
+will change the default behavior to use `hashicorp/go-metrics` instead of `armon/go-metrics`. At that point in time, any application that
+needs more time before performing the migration must instrument their build system to include the `armonmetrics` tag. A subsequent release
+after that will eventually remove the compatibility layer all together. The rough timeline for this will be mid-2025 for changing the default 
+behavior and then the end of 2025 for removal of the compatibility layer.
+
+
 Examples
 --------
 

--- a/compat/armon.go
+++ b/compat/armon.go
@@ -1,0 +1,129 @@
+//go:build armonmetrics || ignore || !hashicorpmetrics
+// +build armonmetrics ignore !hashicorpmetrics
+
+package metrics
+
+import (
+	"io"
+	"net/url"
+	"syscall"
+	"time"
+
+	"github.com/armon/go-metrics"
+)
+
+const (
+	// DefaultSignal is used with DefaultInmemSignal
+	DefaultSignal = metrics.DefaultSignal
+)
+
+func AddSample(key []string, val float32) {
+	metrics.AddSample(key, val)
+}
+func AddSampleWithLabels(key []string, val float32, labels []Label) {
+	metrics.AddSampleWithLabels(key, val, labels)
+}
+func EmitKey(key []string, val float32) {
+	metrics.EmitKey(key, val)
+}
+func IncrCounter(key []string, val float32) {
+	metrics.IncrCounter(key, val)
+}
+func IncrCounterWithLabels(key []string, val float32, labels []Label) {
+	metrics.IncrCounterWithLabels(key, val, labels)
+}
+func MeasureSince(key []string, start time.Time) {
+	metrics.MeasureSince(key, start)
+}
+func MeasureSinceWithLabels(key []string, start time.Time, labels []Label) {
+	metrics.MeasureSinceWithLabels(key, start, labels)
+}
+func SetGauge(key []string, val float32) {
+	metrics.SetGauge(key, val)
+}
+func SetGaugeWithLabels(key []string, val float32, labels []Label) {
+	metrics.SetGaugeWithLabels(key, val, labels)
+}
+func Shutdown() {
+	metrics.Shutdown()
+}
+func UpdateFilter(allow, block []string) {
+	metrics.UpdateFilter(allow, block)
+}
+func UpdateFilterAndLabels(allow, block, allowedLabels, blockedLabels []string) {
+	metrics.UpdateFilterAndLabels(allow, block, allowedLabels, blockedLabels)
+}
+
+type AggregateSample = metrics.AggregateSample
+type BlackholeSink = metrics.BlackholeSink
+type Config = metrics.Config
+type Encoder = metrics.Encoder
+type FanoutSink = metrics.FanoutSink
+type GaugeValue = metrics.GaugeValue
+type InmemSignal = metrics.InmemSignal
+type InmemSink = metrics.InmemSink
+type IntervalMetrics = metrics.IntervalMetrics
+type Label = metrics.Label
+type MetricSink = metrics.MetricSink
+type Metrics = metrics.Metrics
+type MetricsSummary = metrics.MetricsSummary
+type PointValue = metrics.PointValue
+type SampledValue = metrics.SampledValue
+type ShutdownSink = metrics.ShutdownSink
+type StatsdSink = metrics.StatsdSink
+type StatsiteSink = metrics.StatsiteSink
+
+func DefaultConfig(serviceName string) *Config {
+	return metrics.DefaultConfig(serviceName)
+}
+
+func DefaultInmemSignal(inmem *InmemSink) *InmemSignal {
+	return metrics.DefaultInmemSignal(inmem)
+}
+func NewInmemSignal(inmem *InmemSink, sig syscall.Signal, w io.Writer) *InmemSignal {
+	return metrics.NewInmemSignal(inmem, sig, w)
+}
+
+func NewInmemSink(interval, retain time.Duration) *InmemSink {
+	return metrics.NewInmemSink(interval, retain)
+}
+
+func NewIntervalMetrics(intv time.Time) *IntervalMetrics {
+	return metrics.NewIntervalMetrics(intv)
+}
+
+func NewInmemSinkFromURL(u *url.URL) (MetricSink, error) {
+	return metrics.NewInmemSinkFromURL(u)
+}
+
+func NewMetricSinkFromURL(urlStr string) (MetricSink, error) {
+	return metrics.NewMetricSinkFromURL(urlStr)
+}
+
+func NewStatsdSinkFromURL(u *url.URL) (MetricSink, error) {
+	return metrics.NewStatsdSinkFromURL(u)
+}
+
+func NewStatsiteSinkFromURL(u *url.URL) (MetricSink, error) {
+	return metrics.NewStatsiteSinkFromURL(u)
+}
+
+func Default() *Metrics {
+	return metrics.Default()
+}
+
+func New(conf *Config, sink MetricSink) (*Metrics, error) {
+	return metrics.New(conf, sink)
+}
+
+func NewGlobal(conf *Config, sink MetricSink) (*Metrics, error) {
+	return metrics.NewGlobal(conf, sink)
+}
+
+func NewStatsdSink(addr string) (*StatsdSink, error) {
+	return metrics.NewStatsdSink(addr)
+}
+
+func NewStatsiteSink(addr string) (*StatsiteSink, error) {
+	return metrics.NewStatsiteSink(addr)
+}

--- a/compat/circonus/armon.go
+++ b/compat/circonus/armon.go
@@ -1,0 +1,15 @@
+//go:build armonmetrics || ignore || !hashicorpmetrics
+// +build armonmetrics ignore !hashicorpmetrics
+
+package circonus
+
+import (
+	"github.com/armon/go-metrics/circonus"
+)
+
+type CirconusSink = circonus.CirconusSink
+type Config = circonus.Config
+
+func NewCirconusSink(cc *Config) (*CirconusSink, error) {
+	return circonus.NewCirconusSink(cc)
+}

--- a/compat/circonus/hashicorp.go
+++ b/compat/circonus/hashicorp.go
@@ -1,0 +1,15 @@
+//go:build hashicorpmetrics
+// +build hashicorpmetrics
+
+package circonus
+
+import (
+	"github.com/hashicorp/go-metrics/circonus"
+)
+
+type CirconusSink = circonus.CirconusSink
+type Config = circonus.Config
+
+func NewCirconusSink(cc *Config) (*CirconusSink, error) {
+	return circonus.NewCirconusSink(cc)
+}

--- a/compat/datadog/armon.go
+++ b/compat/datadog/armon.go
@@ -1,0 +1,14 @@
+//go:build armonmetrics || ignore || !hashicorpmetrics
+// +build armonmetrics ignore !hashicorpmetrics
+
+package datadog
+
+import (
+	"github.com/armon/go-metrics/datadog"
+)
+
+type DogStatsdSink = datadog.DogStatsdSink
+
+func NewDogStatsdSink(addr string, hostName string) (*DogStatsdSink, error) {
+	return datadog.NewDogStatsdSink(addr, hostName)
+}

--- a/compat/datadog/hashicorp.go
+++ b/compat/datadog/hashicorp.go
@@ -1,0 +1,14 @@
+//go:build hashicorpmetrics
+// +build hashicorpmetrics
+
+package datadog
+
+import (
+	"github.com/hashicorp/go-metrics/datadog"
+)
+
+type DogStatsdSink = datadog.DogStatsdSink
+
+func NewDogStatsdSink(addr string, hostName string) (*DogStatsdSink, error) {
+	return datadog.NewDogStatsdSink(addr, hostName)
+}

--- a/compat/hashicorp.go
+++ b/compat/hashicorp.go
@@ -1,0 +1,129 @@
+//go:build hashicorpmetrics
+// +build hashicorpmetrics
+
+package metrics
+
+import (
+	"io"
+	"net/url"
+	"syscall"
+	"time"
+
+	"github.com/hashicorp/go-metrics"
+)
+
+const (
+	// DefaultSignal is used with DefaultInmemSignal
+	DefaultSignal = metrics.DefaultSignal
+)
+
+func AddSample(key []string, val float32) {
+	metrics.AddSample(key, val)
+}
+func AddSampleWithLabels(key []string, val float32, labels []Label) {
+	metrics.AddSampleWithLabels(key, val, labels)
+}
+func EmitKey(key []string, val float32) {
+	metrics.EmitKey(key, val)
+}
+func IncrCounter(key []string, val float32) {
+	metrics.IncrCounter(key, val)
+}
+func IncrCounterWithLabels(key []string, val float32, labels []Label) {
+	metrics.IncrCounterWithLabels(key, val, labels)
+}
+func MeasureSince(key []string, start time.Time) {
+	metrics.MeasureSince(key, start)
+}
+func MeasureSinceWithLabels(key []string, start time.Time, labels []Label) {
+	metrics.MeasureSinceWithLabels(key, start, labels)
+}
+func SetGauge(key []string, val float32) {
+	metrics.SetGauge(key, val)
+}
+func SetGaugeWithLabels(key []string, val float32, labels []Label) {
+	metrics.SetGaugeWithLabels(key, val, labels)
+}
+func Shutdown() {
+	metrics.Shutdown()
+}
+func UpdateFilter(allow, block []string) {
+	metrics.UpdateFilter(allow, block)
+}
+func UpdateFilterAndLabels(allow, block, allowedLabels, blockedLabels []string) {
+	metrics.UpdateFilterAndLabels(allow, block, allowedLabels, blockedLabels)
+}
+
+type AggregateSample = metrics.AggregateSample
+type BlackholeSink = metrics.BlackholeSink
+type Config = metrics.Config
+type Encoder = metrics.Encoder
+type FanoutSink = metrics.FanoutSink
+type GaugeValue = metrics.GaugeValue
+type InmemSignal = metrics.InmemSignal
+type InmemSink = metrics.InmemSink
+type IntervalMetrics = metrics.IntervalMetrics
+type Label = metrics.Label
+type MetricSink = metrics.MetricSink
+type Metrics = metrics.Metrics
+type MetricsSummary = metrics.MetricsSummary
+type PointValue = metrics.PointValue
+type SampledValue = metrics.SampledValue
+type ShutdownSink = metrics.ShutdownSink
+type StatsdSink = metrics.StatsdSink
+type StatsiteSink = metrics.StatsiteSink
+
+func DefaultConfig(serviceName string) *Config {
+	return metrics.DefaultConfig(serviceName)
+}
+
+func DefaultInmemSignal(inmem *InmemSink) *InmemSignal {
+	return metrics.DefaultInmemSignal(inmem)
+}
+func NewInmemSignal(inmem *InmemSink, sig syscall.Signal, w io.Writer) *InmemSignal {
+	return metrics.NewInmemSignal(inmem, sig, w)
+}
+
+func NewInmemSink(interval, retain time.Duration) *InmemSink {
+	return metrics.NewInmemSink(interval, retain)
+}
+
+func NewIntervalMetrics(intv time.Time) *IntervalMetrics {
+	return metrics.NewIntervalMetrics(intv)
+}
+
+func NewInmemSinkFromURL(u *url.URL) (MetricSink, error) {
+	return metrics.NewInmemSinkFromURL(u)
+}
+
+func NewMetricSinkFromURL(urlStr string) (MetricSink, error) {
+	return metrics.NewMetricSinkFromURL(urlStr)
+}
+
+func NewStatsdSinkFromURL(u *url.URL) (MetricSink, error) {
+	return metrics.NewStatsdSinkFromURL(u)
+}
+
+func NewStatsiteSinkFromURL(u *url.URL) (MetricSink, error) {
+	return metrics.NewStatsiteSinkFromURL(u)
+}
+
+func Default() *Metrics {
+	return metrics.Default()
+}
+
+func New(conf *Config, sink MetricSink) (*Metrics, error) {
+	return metrics.New(conf, sink)
+}
+
+func NewGlobal(conf *Config, sink MetricSink) (*Metrics, error) {
+	return metrics.NewGlobal(conf, sink)
+}
+
+func NewStatsdSink(addr string) (*StatsdSink, error) {
+	return metrics.NewStatsdSink(addr)
+}
+
+func NewStatsiteSink(addr string) (*StatsiteSink, error) {
+	return metrics.NewStatsiteSink(addr)
+}

--- a/compat/prometheus/armon.go
+++ b/compat/prometheus/armon.go
@@ -1,0 +1,31 @@
+//go:build armonmetrics || ignore || !hashicorpmetrics
+// +build armonmetrics ignore !hashicorpmetrics
+
+package prometheus
+
+import (
+	"time"
+
+	"github.com/armon/go-metrics/prometheus"
+)
+
+var DefaultPrometheusOpts = prometheus.DefaultPrometheusOpts
+
+type CounterDefinition = prometheus.CounterDefinition
+type GaugeDefinition = prometheus.GaugeDefinition
+type PrometheusOpts = prometheus.PrometheusOpts
+type PrometheusPushSink = prometheus.PrometheusPushSink
+type PrometheusSink = prometheus.PrometheusSink
+type SummaryDefinition = prometheus.SummaryDefinition
+
+func NewPrometheusPushSink(address string, pushInterval time.Duration, name string) (*PrometheusPushSink, error) {
+	return prometheus.NewPrometheusPushSink(address, pushInterval, name)
+}
+
+func NewPrometheusSink() (*PrometheusSink, error) {
+	return prometheus.NewPrometheusSink()
+}
+
+func NewPrometheusSinkFrom(opts PrometheusOpts) (*PrometheusSink, error) {
+	return prometheus.NewPrometheusSinkFrom(opts)
+}

--- a/compat/prometheus/hashicorp.go
+++ b/compat/prometheus/hashicorp.go
@@ -1,0 +1,31 @@
+//go:build hashicorpmetrics
+// +build hashicorpmetrics
+
+package prometheus
+
+import (
+	"time"
+
+	"github.com/hashicorp/go-metrics/prometheus"
+)
+
+var DefaultPrometheusOpts = prometheus.DefaultPrometheusOpts
+
+type CounterDefinition = prometheus.CounterDefinition
+type GaugeDefinition = prometheus.GaugeDefinition
+type PrometheusOpts = prometheus.PrometheusOpts
+type PrometheusPushSink = prometheus.PrometheusPushSink
+type PrometheusSink = prometheus.PrometheusSink
+type SummaryDefinition = prometheus.SummaryDefinition
+
+func NewPrometheusPushSink(address string, pushInterval time.Duration, name string) (*PrometheusPushSink, error) {
+	return prometheus.NewPrometheusPushSink(address, pushInterval, name)
+}
+
+func NewPrometheusSink() (*PrometheusSink, error) {
+	return prometheus.NewPrometheusSink()
+}
+
+func NewPrometheusSinkFrom(opts PrometheusOpts) (*PrometheusSink, error) {
+	return prometheus.NewPrometheusSinkFrom(opts)
+}

--- a/go.mod
+++ b/go.mod
@@ -4,16 +4,14 @@ go 1.12
 
 require (
 	github.com/DataDog/datadog-go v3.2.0+incompatible
+	github.com/armon/go-metrics v0.4.1
 	github.com/circonus-labs/circonus-gometrics v2.3.1+incompatible
-	github.com/circonus-labs/circonusllhist v0.1.3 // indirect
 	github.com/golang/protobuf v1.4.3
 	github.com/hashicorp/go-immutable-radix v1.0.0
-	github.com/hashicorp/go-retryablehttp v0.5.3 // indirect
 	github.com/pascaldekloe/goe v0.1.0
 	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.26.0
-	github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926 // indirect
 )
 
 // Introduced undocumented breaking change to metrics sink interface

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
+github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -57,6 +59,7 @@ github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCO
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
+github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
@@ -87,6 +90,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
+github.com/prometheus/client_golang v1.4.0/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.1 h1:+4eQaD7vAZ6DsfsxB15hbE0odUjGI5ARs9yskGu1v4s=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
@@ -95,11 +99,13 @@ github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:
 github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
+github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0 h1:iMAkS2TDoNWnKM+Kopnx/8tnEStIfpYA0ur0xQzzhMQ=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
@@ -135,6 +141,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
Introduce the backwards compatibility layer with armon/go-metrics.

The `compat` package (and its sub-packages) are API compatible with `armon/go-metrics@v0.4.1` or `hashicorp/go-metrics@v0.5.0`. The underlying metrics module will be selected for all consumers of the `compat` package by utilizing Go build tags.

* `armonmetrics` - Using this tag will cause metrics to be emitted via `armon/go-metrics`
* `hashicorpmetrics` - Using this tag will cause metrics to be emitted via `hashicorp/go-metrics`

If no build tag is specified the default behavior will be to use `armon/go-metrics` (however this behavior will be scheduled to change in 6 months).

The intention is that libraries will be updated to consume the `compat` package and then applications/services that produce the final binaries can use the build tags to control metrics emission globally for all libraries.