### PR TITLE
IND-3830 enabling dependabot, changelog addition

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[chore] : "
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "[chore] : "

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -14,8 +14,15 @@ jobs:
               uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a
               with:
                 go-version: '1.23'
-            - name: Run Tests
-              run: go test ./...
+            - name: Run Tests and Generate Coverage report
+              run: go test -v -coverprofile=coverage.out ./...
+            - name: Upload Coverage report
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02   # v4.6.2
+              with:
+                path: coverage.out
+                name: Coverage-report
+            - name: Display Coverage report
+              run: go tool cover -func=coverage.out
             - name: Run Linter
               uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
               with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## Unreleased
+
+### Improvements
+
+### Changes
+
+### Fixed
+
+### Security


### PR DESCRIPTION
- As per the memo: https://go.hashi.co/memo/eng-004,
Enabling the dependabot for identifying and updating the security and version updates in the repositories rather handling it manually.
- Adding the CHANGELOG.md file to maintain standardisation across OSS core libraries
- Updated build-test.yml workflow in order to test and generate code coverage report and uploading the same in artifacts for further use.